### PR TITLE
use GitHub instructions 

### DIFF
--- a/workshop/README.md
+++ b/workshop/README.md
@@ -74,12 +74,21 @@ The tests are not complete and there are some missing cases. Use GitHub Copilot 
 
 ### 6. Create Rust scaffolding
 
-Now that you have a good understanding of the project and its tests, you can start creating the Rust scaffolding. Use GitHub Copilot to help you with this. To simplify this process, assume the following guidelines for the Rust project:
+Now that you have a good understanding of the project and its tests, you can start creating the Rust scaffolding. You will start by creating a special file with instructions. This file is called _Copilot Instructions_ and it should live in the root of the current repository. We've pre-created an empty file for you so all is needed is to fill it out with new instructions.
 
-- Use `actix-web` for the web framework
-- Use `serde` for JSON serialization and deserialization
+For this step, open the `.github/copilot-instructions.md` file and add the
+following:
 
-Ask GitHub Copilot to give you a step by step to start the project and the commands to run to get started.
+```markdown
+Whenever you are providing suggestions for a Rust project always use the
+actix-web framework using serde for serialization
+```
+
+Now use GitHub Copilot in Agent mode to create the scaffolding necessary for
+your Rust project. Ask GitHub Copilot to give you a step by step to start the project and the commands to run to get started.
+
+The framework and the serializer should automatically be included without you having to specify it. This file can be used for any other instruction you don't want to repeat.
+
 
 > [!NOTE]
 > Why the dependencies might not fully work? Because LLMs sometimes don't have correct versions and tend to provide probabilistic results, not exact ones like a database would. Ensure that the versions used and installed will work and are correct.

--- a/workshop/README.md
+++ b/workshop/README.md
@@ -74,7 +74,7 @@ The tests are not complete and there are some missing cases. Use GitHub Copilot 
 
 ### 6. Create Rust scaffolding
 
-Now that you have a good understanding of the project and its tests, you can start creating the Rust scaffolding. You will start by creating a special file with instructions. This file is called _Copilot Instructions_ and it should live in the root of the current repository. We've pre-created an empty file for you so all is needed is to fill it out with new instructions.
+Now that you have a good understanding of the project and its tests, you can start creating the Rust scaffolding. You will start by creating a special file with instructions. This file is called _Copilot Instructions_ and it should live in the root of the current repository. We've pre-created an empty file for you so all that is needed is to fill it out with new instructions.
 
 For this step, open the `.github/copilot-instructions.md` file and add the
 following:


### PR DESCRIPTION
Fixes #5 

Adds usage of `copilot-instructions.md` as well as a placeholder for it so that users aren't required to create it in the lab